### PR TITLE
feat: Post Create Refactor (#41)

### DIFF
--- a/src/main/java/com/example/classhub/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/classhub/domain/post/controller/PostController.java
@@ -1,18 +1,24 @@
 package com.example.classhub.domain.post.controller;
 
-import com.example.classhub.domain.datadetail.dto.DataDetailDto;
 import com.example.classhub.domain.datadetail.service.DataDetailService;
+import com.example.classhub.domain.post.controller.request.PostCheckRequest;
 import com.example.classhub.domain.post.controller.request.PostCreateRequest;
 import com.example.classhub.domain.post.controller.response.PostListResponse;
 import com.example.classhub.domain.post.dto.PostDto;
 import com.example.classhub.domain.post.service.PostService;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 @Controller
 @RequiredArgsConstructor
@@ -26,10 +32,52 @@ public class PostController {
         model.addAttribute("post", new PostCreateRequest());
         return "postForm";
     }
+
     @PostMapping("/post/postForm")
-    public String postForm(@ModelAttribute("postForm") PostCreateRequest request, @RequestParam("file") MultipartFile file){
-        postService.savePost(PostDto.from(request), file);
-//        dataDetailService.saveDataDetail(DataDetailDto.from(file));
+    public String postForm(@ModelAttribute("postForm") PostCreateRequest request, @RequestParam("file") MultipartFile file, RedirectAttributes redirectAttributes, HttpSession session) throws IOException {
+        // 임시 파일 생성 및 세션에 파일 경로 저장
+        String tempDir = System.getProperty("java.io.tmpdir");
+        File tempFile = new File(tempDir, file.getOriginalFilename());
+        file.transferTo(tempFile);
+
+        session.setAttribute("filePath", tempFile.getAbsolutePath());
+        session.setAttribute("postForm", request);
+
+        List<String> headers = postService.checkHeader(tempFile); // 수정된 부분: MultipartFile 대신 File 사용
+        redirectAttributes.addFlashAttribute("headers", headers);
+        return "redirect:/post/postHeaderCheckForm";
+    }
+
+    @GetMapping("/post/postHeaderCheckForm")
+    public String postHeaderCheckForm(@ModelAttribute("headers") List<String> headers, HttpSession session, Model model){
+        MultipartFile file = (MultipartFile) session.getAttribute("file");
+
+        model.addAttribute("headers", headers);
+        model.addAttribute("file", file);
+        return "postHeaderCheckForm";
+    }
+
+    @PostMapping("/post/postHeaderCheckForm")
+    public String savePost(@RequestParam(required = false) List<Boolean> isSelected,
+                           @RequestParam(required = false) List<Boolean> isScore,
+                           HttpSession session) throws IOException {
+
+        String filePath = (String) session.getAttribute("filePath");
+        File file = new File(filePath);
+
+        PostCreateRequest postCreateRequest = (PostCreateRequest) session.getAttribute("postForm");
+        PostCheckRequest postCheckRequest = new PostCheckRequest();
+
+        postCheckRequest.setIsSelected(isSelected);
+        postCheckRequest.setIsScore(isScore);
+
+        if (isSelected != null && isSelected.contains(true)) {
+            postCheckRequest.setTagNames(postService.checkHeader(file));
+        }
+        System.out.println("postCheckRequest.getTagNames()" + postCheckRequest.getTagNames());
+
+
+        postService.createPost(PostDto.from(postCreateRequest, postCheckRequest), file);
         return "redirect:/post/postList";
     }
 

--- a/src/main/java/com/example/classhub/domain/post/controller/request/HeaderRequest.java
+++ b/src/main/java/com/example/classhub/domain/post/controller/request/HeaderRequest.java
@@ -1,0 +1,12 @@
+package com.example.classhub.domain.post.controller.request;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@Data
+public class HeaderRequest {
+    private List<String> headers;
+}

--- a/src/main/java/com/example/classhub/domain/post/controller/request/PostCheckRequest.java
+++ b/src/main/java/com/example/classhub/domain/post/controller/request/PostCheckRequest.java
@@ -1,0 +1,14 @@
+package com.example.classhub.domain.post.controller.request;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@Data
+public class PostCheckRequest {
+    private List<String> tagNames;
+    private List<Boolean> isSelected;
+    private List<Boolean> isScore;
+}

--- a/src/main/java/com/example/classhub/domain/post/dto/PostDto.java
+++ b/src/main/java/com/example/classhub/domain/post/dto/PostDto.java
@@ -1,12 +1,15 @@
 package com.example.classhub.domain.post.dto;
 
 import com.example.classhub.domain.post.ClassHub_Post;
+import com.example.classhub.domain.post.controller.request.PostCheckRequest;
 import com.example.classhub.domain.post.controller.request.PostCreateRequest;
 import com.example.classhub.domain.post.controller.request.PostUpdateRequest;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -19,14 +22,32 @@ public class PostDto {
     private String postShareRange;
     private String tagId;
     private Long lRoomId;
+    private List<Boolean> isSelected;
+    private List<Boolean> isScore;
 
     public static PostDto from(PostCreateRequest postCreateRequest) {
         return PostDto.builder()
                 .postTitle(postCreateRequest.getPostTitle())
                 .postContent(postCreateRequest.getPostContent())
                 .postShareRange(postCreateRequest.getPostShareRange())
-//                .tagId(postCreateRequest.getTagId())
                 .lRoomId(postCreateRequest.getLRoomId())
+                .build();
+    }
+    public static PostDto from(PostCheckRequest postCheckRequest) {
+        return PostDto.builder()
+                .isSelected(postCheckRequest.getIsSelected())
+                .isScore(postCheckRequest.getIsScore())
+                .build();
+    }
+
+    public static PostDto from(PostCreateRequest postCreateRequest, PostCheckRequest postCheckRequest){
+        return PostDto.builder()
+                .postTitle(postCreateRequest.getPostTitle())
+                .postContent(postCreateRequest.getPostContent())
+                .postShareRange(postCreateRequest.getPostShareRange())
+                .lRoomId(postCreateRequest.getLRoomId())
+                .isSelected(postCheckRequest.getIsSelected())
+                .isScore(postCheckRequest.getIsScore())
                 .build();
     }
 

--- a/src/main/java/com/example/classhub/domain/post/service/PostService.java
+++ b/src/main/java/com/example/classhub/domain/post/service/PostService.java
@@ -20,12 +20,10 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -40,62 +38,64 @@ public class PostService {
     private final TagService tagService;
     private final DataDetailService dataDetailService;
 
-    public String getFileDataName(MultipartFile file) {
-        String originalFilename = file.getOriginalFilename();
-        String[] filenameParts = originalFilename.split("\\.");
-        return filenameParts[0]; // 파일 이름
-    }
-
-    public String getFileDataType(MultipartFile file) {
-        String originalFilename = file.getOriginalFilename();
-        String[] filenameParts = originalFilename.split("\\.");
-        return filenameParts.length > 1 ? filenameParts[filenameParts.length - 1] : ""; // 확장자
-    }
-
-    @Transactional
-    public String saveTag(ClassHub_LRoom lRoom, MultipartFile csvFile) {
-        StringBuilder tagIdsBuilder = new StringBuilder();
+    public List<String> checkHeader(File file) { // 수정된 부분: MultipartFile 대신 File 사용
         List<CSVRecord> records = new ArrayList<>();
-        try (BOMInputStream bomInputStream = new BOMInputStream(csvFile.getInputStream());
-             BufferedReader fileReader = new BufferedReader(new InputStreamReader(bomInputStream, StandardCharsets.UTF_8));
-             CSVParser csvParser = new CSVParser(fileReader, CSVFormat.DEFAULT.withFirstRecordAsHeader().withIgnoreHeaderCase().withTrim())) {
+        try (FileInputStream fis = new FileInputStream(file);
+             BOMInputStream bomInputStream = new BOMInputStream(fis, false); // BOMInputStream을 사용하여 BOM을 처리
+             BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(bomInputStream, StandardCharsets.UTF_8));
+             CSVParser csvParser = new CSVParser(bufferedReader, CSVFormat.DEFAULT.withFirstRecordAsHeader().withIgnoreHeaderCase().withTrim())) {
 
             for (CSVRecord record : csvParser) {
                 records.add(record);
             }
+        } catch (IOException e) {
+            throw new RuntimeException("fail to parse CSV file: " + e.getMessage());
+        }
+        return new ArrayList<>(records.get(0).toMap().keySet());
+    }
 
+    @Transactional
+    public String saveTag(ClassHub_LRoom lRoom, File csvFile, List<Boolean> isSelected, List<Boolean> isScore) throws IOException {
+        StringBuilder tagIdsBuilder = new StringBuilder();
+        List<CSVRecord> records = new ArrayList<>();
+
+        try (FileInputStream fis = new FileInputStream(csvFile);
+             BOMInputStream bomInputStream = new BOMInputStream(fis, false); // BOMInputStream을 사용하여 BOM을 처리
+             BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(bomInputStream, StandardCharsets.UTF_8));
+             CSVParser csvParser = new CSVParser(bufferedReader, CSVFormat.DEFAULT.withFirstRecordAsHeader().withIgnoreHeaderCase().withTrim())) {
+
+            records.addAll(csvParser.getRecords());
             Map<String, Integer> headers = csvParser.getHeaderMap();
-            for (String headerName : headers.keySet()) {
-                int headerIndex = headers.get(headerName);
-                boolean isScore = headerName.contains("score");
+            List<String> headerNames = new ArrayList<>(headers.keySet());
 
-                String tagName = isScore ? headerName.replace("(score)", "").trim() : headerName;
+            for (int i = 0; i < headerNames.size(); i++) {
+                if (!isSelected.get(i)) continue;
 
-                if(headerName.equals("학번")){
-                    continue;
-                }
+                String headerName = headerNames.get(i);
+                boolean isScoreTag = isScore.get(i);
+
                 TagDto tagDto = TagDto.builder()
-                        .name(tagName)
+                        .name(headerName)
                         .lRoomId(lRoom.getLRoomId())
-                        .nan(!isScore)
+                        .nan(!isScoreTag)
                         .build();
                 TagDto createdTagDto = tagService.createTag(tagDto, lRoom.getLRoomId());
 
+                // 각 레코드에 대해 처리합니다.
                 for (CSVRecord record : records) {
-                    String recordValue = record.get(headerIndex);
-                    System.out.println("Record for Header " + headerName + ": " + recordValue);
-                    if(isScore){
+                    if (isScoreTag) {
+                        // 점수 태그인 경우
                         DataDetailDto dataDetail = DataDetailDto.builder()
                                 .studentNum(record.get("학번"))
-                                .score(Double.valueOf(recordValue))
+                                .score(Double.parseDouble(record.get(headerName)))
                                 .tagId(createdTagDto.getTagId())
                                 .build();
                         dataDetailService.saveDataDetail(dataDetail);
-                    }
-                    else {
+                    } else {
+                        // 코멘트 태그인 경우
                         DataDetailDto dataDetail = DataDetailDto.builder()
                                 .studentNum(record.get("학번"))
-                                .comment(recordValue)
+                                .comment(record.get(headerName))
                                 .tagId(createdTagDto.getTagId())
                                 .build();
                         dataDetailService.saveDataDetail(dataDetail);
@@ -105,10 +105,8 @@ public class PostService {
                 Long tagId = createdTagDto.getTagId();
                 tagIdsBuilder.append(tagId).append(",");
             }
-
-        } catch (IOException e) {
-            throw new RuntimeException("fail to parse CSV file: " + e.getMessage());
         }
+
         String tagIds = tagIdsBuilder.toString();
         if (tagIds.endsWith(",")) {
             tagIds = tagIds.substring(0, tagIds.length() - 1);
@@ -118,25 +116,33 @@ public class PostService {
 
 
     @Transactional
-    public void savePost(PostDto postDto, MultipartFile file) {
+    public void createPost(PostDto postDto, File file) throws IOException {
         ClassHub_LRoom lRoom = lectureRoomRepository.findById(postDto.getLRoomId())
                 .orElseThrow(() -> new IllegalArgumentException("해당 강의실이 존재하지 않습니다."));
 
-        if (!file.isEmpty()) {
-            String tagIds = saveTag(lRoom, file);
+        if (file.length() == 0) {
+            ClassHub_Post post = ClassHub_Post.from(postDto, lRoom);
+            System.out.println("Post: " + post);
+            postRepository.save(post);
+        } else {
+            String tagIds = saveTag(lRoom, file, postDto.getIsSelected(), postDto.getIsScore());
+
+            System.out.println("TagIds: " + tagIds);
             ClassHub_Post post = ClassHub_Post.from(postDto, lRoom, tagIds);
             postRepository.save(post);
 
+            String fileDataName = file.getName();
+            String fileDataType = Files.probeContentType(file.toPath());
+
             FileDataDto fileDataDto = FileDataDto.builder()
-                    .fileDataName(getFileDataName(file))
-                    .fileDataType(getFileDataType(file))
+                    .fileDataName(fileDataName)
+                    .fileDataType(fileDataType)
                     .postId(post.getPostId())
                     .build();
             fileDataService.saveFileData(fileDataDto);
-        } else {
-            ClassHub_Post post = ClassHub_Post.from(postDto, lRoom);
-            postRepository.save(post);
         }
+
+        file.delete();
     }
     @Transactional
     public PostListResponse getPostList(){

--- a/src/main/resources/templates/postForm.html
+++ b/src/main/resources/templates/postForm.html
@@ -41,7 +41,6 @@
 
         <button type="submit">저장</button>
     </form>
-
 </div>
     <!-- 부트스트랩 JS 추가 (부트스트랩 컴포넌트들의 동적 기능을 위해 필요, 예: 모달, 드롭다운 등) -->
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>

--- a/src/main/resources/templates/postHeaderCheckForm.html
+++ b/src/main/resources/templates/postHeaderCheckForm.html
@@ -1,0 +1,32 @@
+<form action="#" th:action="@{/post/postHeaderCheckForm}" th:object="${headers}" method="post" enctype="multipart/form-data">
+    <h2>생성될 태그 목록</h2>
+    <table>
+        <thead>
+        <tr>
+            <th>No.</th>
+            <th>찾은 헤더 이름</th>
+            <th>점수 여부</th>
+            <th>태그 생성 여부</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="header, index : ${headers}">
+            <td th:text="${index.index + 1}"></td>
+            <td th:text="${header}"></td>
+            <td>
+                <!-- name을 isSelected로 변경 -->
+                <input type="checkbox" th:id="'scoreCheckbox' + ${index}" th:name="'isScore'" th:value="true">
+                <!-- 선택되지 않은 경우를 위해 숨겨진 필드 추가 -->
+                <input type="hidden" th:name="'isScore'" th:value="false">
+            </td>
+            <td>
+                <!-- name을 isScore로 변경 -->
+                <input type="checkbox" th:id="'createCheckbox' + ${index}" th:name="'isSelected'" th:value="true">
+                <!-- 선택되지 않은 경우를 위해 숨겨진 필드 추가 -->
+                <input type="hidden" th:name="'isSelected'" th:value="false">
+            </td>
+        </tr>
+        </tbody>
+    </table>
+    <button type="submit">게시물 등록</button>
+</form>


### PR DESCRIPTION
기존의 하나의 api에서 포스트 생성, 태그 생성, 디테일 데이터 생성을 2개의 단계로 나눔. 입력한 파일을 기준으로 헤더를 파싱한 후 유저가 선택한 헤더들로 태그 생성 후 데이터 저장