### PR TITLE
feat: index.html에서 개인정보 수정, 이메일 수정만 할 수 있도록 변경 (#132)

### DIFF
--- a/src/main/java/com/example/classhub/domain/member/ClassHub_Member.java
+++ b/src/main/java/com/example/classhub/domain/member/ClassHub_Member.java
@@ -44,4 +44,8 @@ public class ClassHub_Member extends BaseEntity {
         this.uniqueId = memberDto.getUniqueId();
     }
 
+    public void updateEmail(MemberDto memberDto) {
+        this.email = memberDto.getEmail();
+    }
+
 }

--- a/src/main/java/com/example/classhub/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/classhub/domain/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.example.classhub.domain.member.controller;
 import com.example.classhub.domain.classhub_lroom.dto.LectureRoomDto;
 import com.example.classhub.domain.classhub_lroom.service.LectureRoomService;
 import com.example.classhub.domain.member.controller.request.MemberCreateRequest;
+import com.example.classhub.domain.member.controller.request.MemberEmailUpdateRequest;
 import com.example.classhub.domain.member.controller.response.MemberListResponse;
 import com.example.classhub.domain.member.dto.MemberDto;
 import com.example.classhub.domain.member.service.MemberService;
@@ -13,6 +14,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import javax.servlet.http.HttpSession;
+import java.security.Principal;
 
 @Controller
 @RequiredArgsConstructor
@@ -33,11 +37,6 @@ public class MemberController {
     return "/member";
   }
 
-//  @GetMapping("/login") // member form 보여주기
-//  public String createMemberForm(Model model){
-//    model.addAttribute("member", new LoginRequest());
-//    return "/member/login";
-//  }
 
   @PostMapping("/saveMember") // member 저장하기
   // TODO : hisnet login 연결
@@ -70,4 +69,9 @@ public class MemberController {
     return "redirect:/member";
   }
 
+  @PostMapping("/updateEmail/{memberId}") // member email 수정하기
+  public String updateEmail(@ModelAttribute("memberId") Long memberId, @ModelAttribute("member") MemberEmailUpdateRequest request){
+    memberService.updateEmail(memberId, MemberDto.from(request));
+    return "redirect:/lecture-room";
+  }
 }

--- a/src/main/java/com/example/classhub/domain/member/controller/request/MemberEmailUpdateRequest.java
+++ b/src/main/java/com/example/classhub/domain/member/controller/request/MemberEmailUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.example.classhub.domain.member.controller.request;
+
+
+import lombok.Data;
+
+@Data
+public class MemberEmailUpdateRequest {
+  private String email;
+}

--- a/src/main/java/com/example/classhub/domain/member/dto/MemberDto.java
+++ b/src/main/java/com/example/classhub/domain/member/dto/MemberDto.java
@@ -4,6 +4,7 @@ package com.example.classhub.domain.member.dto;
 import com.example.classhub.domain.member.ClassHub_Member;
 import com.example.classhub.domain.member.controller.request.LoginRequest;
 import com.example.classhub.domain.member.controller.request.MemberCreateRequest;
+import com.example.classhub.domain.member.controller.request.MemberEmailUpdateRequest;
 import com.example.classhub.domain.member.controller.request.MemberUpdateRequest;
 import com.example.classhub.domain.memberlroom.controller.request.MemberLRoomMemberCreateRequest;
 import com.example.classhub.domain.memberlroom.dto.Permission;
@@ -48,6 +49,12 @@ public class MemberDto {
                 .email(request.getEmail())
                 .department(request.getDepartment())
                 .build();
+    }
+
+    public static MemberDto from(MemberEmailUpdateRequest request){
+      return MemberDto.builder()
+        .email(request.getEmail())
+        .build();
     }
 
     public static MemberDto from(ClassHub_Member classHubMember){

--- a/src/main/java/com/example/classhub/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/classhub/domain/member/service/MemberService.java
@@ -94,5 +94,15 @@ public class MemberService {
       return MemberDto.from(classHubMember);
     }
 
+    @Transactional
+    public MemberDto updateEmail(Long memberId, MemberDto memberDto) {
+      ClassHub_Member classHubMember = memberRepository.findById(memberId)
+              .orElseThrow(() -> new IllegalArgumentException("해당 회원이 존재하지 않습니다."));
+      System.out.println("memberDto: " + memberDto);
+      classHubMember.updateEmail(memberDto);
+      memberRepository.save(classHubMember);
+      return MemberDto.from(classHubMember);
+    }
+
 
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -170,9 +170,16 @@
                         <!-- Dropdown - User Information -->
                         <div class="dropdown-menu dropdown-menu-right shadow animated--grow-in"
                              aria-labelledby="userDropdown">
+                            <a class="dropdown-item" href="#" data-toggle="modal" data-target="#updateEmailModal">
+                              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-file-earmark-person mr-2 text-gray-400" viewBox="0 0 16 16">
+                                <path d="M11 8a3 3 0 1 1-6 0 3 3 0 0 1 6 0"/>
+                                <path d="M14 14V4.5L9.5 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2M9.5 3A1.5 1.5 0 0 0 11 4.5h2v9.255S12 12 8 12s-5 1.755-5 1.755V2a1 1 0 0 1 1-1h5.5z"/>
+                              </svg>
+                                개인정보
+                            </a>
                             <a class="dropdown-item" href="#" data-toggle="modal" data-target="#logoutModal">
-                                <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray-400"></i>
-                                로그아웃
+                              <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray-400"></i>
+                              로그아웃
                             </a>
                         </div>
                     </li>
@@ -300,13 +307,51 @@
                     <input type="file" id="studentFile" name="studentFile" class="form-control" style="display: none;">
                 </div>
                 <div class="modal-footer">
-                    <button class="btn btn-primary" data-dismiss="modal" style="background: #adb5bd; border-color: #adb5bd;">닫기</button>
+                    <button class="btn btn-secondary" data-dismiss="modal">닫기</button>
                     <button type="submit" class="btn btn-primary" style="background: #2e59d9; border-color: #2e59d9;">저장</button>
                 </div>
             </form>
         </div>
     </div>
 </div>
+<div class="modal" id="updateEmailModal">
+  <div class="modal-dialog">
+    <div class="modal-content">
+
+      <!-- Modal Header -->
+      <div class="modal-header">
+        <h4 class="modal-title">이메일 수정</h4>
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+      </div>
+
+      <!-- Modal body -->
+      <div class="modal-body">
+        <form id="emailUpdateForm" th:action="@{/updateEmail/{memberId}(memberId=${session.member.memberId})}" method="post">
+          <div class="form-group">
+            <label>이름: </label>
+            <span th:text="${session.member.member_name}"></span>
+          </div>
+          <div class="form-group">
+            <label>학번: </label>
+            <span th:text="${session.member.uniqueId}"></span>
+          </div>
+          <div class="form-group">
+            <label for="email">이메일: </label>
+            <input type="email" class="form-control" id="email" name="email" th:value="${session.member.email}" required>
+          </div>
+        </form>
+      </div>
+
+      <!-- Modal footer -->
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">닫기</button>
+        <button type="submit" class="btn btn-primary" form="emailUpdateForm">수정하기</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+
 
 <!-- Bootstrap core JavaScript-->
 <script src="/ClassHub/bootstrap/vendor/jquery/jquery.min.js"></script>
@@ -346,6 +391,7 @@
         link.click();
         document.body.removeChild(link);
     }
+
 </script>
 </body>
 

--- a/src/main/resources/templates/lectureRoom/lectureRoomInfo.html
+++ b/src/main/resources/templates/lectureRoom/lectureRoomInfo.html
@@ -241,20 +241,6 @@
             filterTags('');
         </script>
 
-        <!-- Nav Item - Charts -->
-<!--   ToDo: tagId로 연결해두기   -->
-<!--        <li class="nav-item">-->
-<!--            <a class="nav-link" th:href="@{'/data-detail/statistics/' + ${lectureRoom.lectureRoomId}}">-->
-<!--                <i class="fas fa-fw fa-chart-area"></i>-->
-<!--                <span>통계자료</span></a>-->
-<!--        </li>-->
-
-        <!-- Nav Item - Tables -->
-<!--        <li class="nav-item">-->
-<!--            <a class="nav-link" href="index.html">-->
-<!--                <i class="fas fa-fw fa-table"></i>-->
-<!--                <span>Tables</span></a>-->
-<!--        </li>-->
         <!-- Divider -->
         <hr class="sidebar-divider">
         <!-- Heading -->

--- a/src/main/resources/templates/lectureRoomDetail.html
+++ b/src/main/resources/templates/lectureRoomDetail.html
@@ -395,7 +395,7 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="exampleModalLabel">로그아웃하시겠습니까?</h5>
+                <h5 class="modal-title" id="logout">로그아웃하시겠습니까?</h5>
                 <button class="close" type="button" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">×</span>
                 </button>


### PR DESCRIPTION
index.html 페이지에서만 프로필 클릭시 개인정보 보이게 함. 개인정보 수정할때, email만 가능하게 했고 그 외에 이름, 학번 정보들은 보여주기만 합니다.